### PR TITLE
Allow user to switch between wrapped grid and void grid

### DIFF
--- a/src/controls.rs
+++ b/src/controls.rs
@@ -261,7 +261,7 @@ pub fn in_upload(x: i32, y: i32) -> bool {
 /// Given x, y coordinates and the wrap state, check to see if it is within the wrap button
 pub fn in_wrap(
     canvas: &Canvas<Window>,
-    text_cache: &mut TextCache,
+    text_cache: &TextCache,
     x: i32,
     y: i32,
     is_wrap: bool

--- a/src/controls.rs
+++ b/src/controls.rs
@@ -22,6 +22,10 @@ const SLIDER_X: i32 = 60;
 const SLIDER_WIDTH: i32 = 120;
 const SLIDER_PADDING: i32 = 2;
 
+// location of wrap button
+const WRAP_X_RIGHT: i32 = 60;  // x-value for top-right, calculated from the right-end
+const WRAP_TEXT_PADDING: i32 = 10;
+
 // icon size and locations
 const ICON_SIZE: i32 = 20;
 const UPLOAD_X: i32 = 60;
@@ -79,6 +83,37 @@ pub fn render_pause(canvas: &mut Canvas<Window>) {
     // render the rectangles
     canvas.fill_rect(left_rect).unwrap();
     canvas.fill_rect(right_rect).unwrap();
+}
+
+/// Render a button that shows whether it is using wrap-around grids
+pub fn render_wrap(canvas: &mut Canvas<Window>, text_cache: &mut TextCache, is_wrap: bool) {
+    // get screen size and set draw color
+    let screen_size: (u32, u32) = canvas.output_size().unwrap();
+    let screen_width = screen_size.0 as i32;
+    let screen_height = screen_size.1 as i32;
+    canvas.set_draw_color(Color::BLACK);
+    let mut button_text = "VOID";
+    if is_wrap {
+        button_text = "WRAP";
+    }
+    
+    // get the text texture
+    let dimensions: (i32, i32) = text_cache.get_dimensions(button_text);
+    let text_texture: &Texture = text_cache.render_text(button_text);
+    let text_x: i32 = screen_width - WRAP_X_RIGHT - dimensions.0 - WRAP_TEXT_PADDING;
+    let text_y: i32 = screen_height - PADDING_BOTTOM - (HEIGHT + dimensions.1) / 2;
+    
+    // create the rectangles
+    let outer_rect = Rect::new(
+        screen_width - WRAP_X_RIGHT - dimensions.0 - WRAP_TEXT_PADDING * 2,
+        screen_height - PADDING_BOTTOM - HEIGHT,
+        (dimensions.0 + WRAP_TEXT_PADDING * 2) as u32,
+        HEIGHT as u32);
+    let text_rect = Rect::new(text_x, text_y, dimensions.0 as u32, dimensions.1 as u32);
+
+    // render the rectangles
+    canvas.draw_rect(outer_rect).unwrap();
+    canvas.copy(text_texture, None, text_rect).unwrap();
 }
 
 /// Render a slider for controlling the speed of the simulation
@@ -202,7 +237,6 @@ pub fn in_pause(canvas: &Canvas<Window>, x: i32, y: i32) -> bool {
     let screen_size: (u32, u32) = canvas.output_size().unwrap();
     let screen_width = screen_size.0 as i32;
     let screen_height = screen_size.1 as i32;
-    let click = Point::new(x, y);
 
     // create the pause bounding rectangle
     let pause_rect = Rect::new((screen_width - PAUSE_BUTTON_DIST) / 2 - PAUSE_BUTTON_WIDTH,
@@ -210,7 +244,7 @@ pub fn in_pause(canvas: &Canvas<Window>, x: i32, y: i32) -> bool {
         (2 * PAUSE_BUTTON_WIDTH + PAUSE_BUTTON_DIST) as u32,
         HEIGHT as u32);
 
-    pause_rect.contains_point(click)
+    pause_rect.contains_point(Point::new(x, y))
 }
 
 /// Given x and y coordinates, check to see if it is within the upload icon
@@ -224,12 +258,41 @@ pub fn in_upload(x: i32, y: i32) -> bool {
     upload_rect.contains_point(Point::new(x, y))
 }
 
+/// Given x, y coordinates and the wrap state, check to see if it is within the wrap button
+pub fn in_wrap(
+    canvas: &Canvas<Window>,
+    text_cache: &mut TextCache,
+    x: i32,
+    y: i32,
+    is_wrap: bool
+) -> bool {
+    // get screen size and set draw color
+    let screen_size: (u32, u32) = canvas.output_size().unwrap();
+    let screen_width = screen_size.0 as i32;
+    let screen_height = screen_size.1 as i32;
+    let mut button_text = "VOID";
+    if is_wrap {
+        button_text = "WRAP";
+    }
+    
+    // get the text texture dimensions
+    let dimensions: (i32, i32) = text_cache.get_dimensions(button_text);
+
+    // get the bounding rectangle
+    let outer_rect = Rect::new(
+        screen_width - WRAP_X_RIGHT - dimensions.0 - WRAP_TEXT_PADDING * 2,
+        screen_height - PADDING_BOTTOM - HEIGHT,
+        (dimensions.0 + WRAP_TEXT_PADDING * 2) as u32,
+        HEIGHT as u32);
+
+    outer_rect.contains_point(Point::new(x, y))
+}
+
 /// Given x and y coordinates, check to see if it is within the slider
 pub fn in_slider(canvas: &Canvas<Window>, x: i32, y: i32) -> bool {
     // get screen size and click point
     let screen_size: (u32, u32) = canvas.output_size().unwrap();
     let screen_height = screen_size.1 as i32;
-    let click = Point::new(x, y);
 
     // create the pause bounding rectangle
     let outer_rect = Rect::new(SLIDER_X,
@@ -237,7 +300,7 @@ pub fn in_slider(canvas: &Canvas<Window>, x: i32, y: i32) -> bool {
         SLIDER_WIDTH as u32,
         HEIGHT as u32);
 
-    outer_rect.contains_point(click)
+    outer_rect.contains_point(Point::new(x, y))
 }
 
 /// Given x coordinates, calculate how long the slider should be

--- a/src/life.rs
+++ b/src/life.rs
@@ -27,7 +27,7 @@ fn apply_rules(cells: &Vec<Vec<bool>>) -> bool {
 }
 
 /// Simulates one generation of the game, returning the updated grid
-pub fn simulate(cells: Vec<Vec<bool>>) -> Vec<Vec<bool>> {
+pub fn simulate(cells: Vec<Vec<bool>>, is_wrap: bool) -> Vec<Vec<bool>> {
     // the new vector of cells to return, representing the next generation
     let rows = cells.len();
     let cols = cells[0].len();
@@ -39,12 +39,26 @@ pub fn simulate(cells: Vec<Vec<bool>>) -> Vec<Vec<bool>> {
             // slice to pass in for rule application
             let mut slice: Vec<Vec<bool>> = vec![vec![false; 3]; 3];
 
-            // utilize wrap-around coordinates and fill the slice
-            for di in 0..3 {
-                for dj in 0..3 {
-                    let row = (i + rows - 1 + di) % rows;
-                    let col = (j + cols - 1 + dj) % cols;
-                    slice[di][dj] = cells[row][col];
+            if is_wrap {
+                // utilize wrap-around coordinates and fill the slice 
+                for di in 0..3 {
+                    for dj in 0..3 {
+                        let row = (i + rows - 1 + di) % rows;
+                        let col = (j + cols - 1 + dj) % cols;
+                        slice[di][dj] = cells[row][col];
+                    }
+                }
+            } else {
+                // make cells disappear after they go past boundary
+                if i == 0 || i == rows - 1 || j == 0 || j == rows - 1 {
+                    ret_cells[i][j] = false;
+                    continue;
+                } else {
+                    for di in 0..3 {
+                        for dj in 0..3 {
+                            slice[di][dj] = cells[i + di - 1][j + dj - 1];
+                        }
+                    }
                 }
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ pub mod ui;
 
 use std::time::{Duration, Instant};
 
-use controls::{calc_slider, in_pause, in_play, in_slider, in_upload, render_pause, render_play, render_slider, render_upload};
+use controls::{calc_slider, in_pause, in_play, in_slider, in_upload, in_wrap, render_pause, render_play, render_slider, render_upload, render_wrap};
 use file::upload;
 use sdl2::image::LoadTexture;
 use text::TextCache;
@@ -71,6 +71,7 @@ fn main() {
     let mut is_simulating = false;
     let mut is_slider_moving = false;
     let mut slider_length: f32 = 1.0;
+    let mut is_wrap = false;
 
     // keep track of time between loops to update simulation
     let mut last_updated = Instant::now();
@@ -94,7 +95,7 @@ fn main() {
         if is_simulating {
             let curr_time = Instant::now();
             if curr_time.duration_since(last_updated) > interval {
-                cells = simulate(cells, false);
+                cells = simulate(cells, is_wrap);
                 last_updated = curr_time;
             }
         }
@@ -132,6 +133,9 @@ fn main() {
 
         // render upload icon
         render_upload(&mut canvas, &upload_texture);
+
+        // render wrap button
+        render_wrap(&mut canvas, &mut text_cache, is_wrap);
 
         // if slider is in moving state, update slider length and set speed
         if is_slider_moving {
@@ -180,6 +184,11 @@ fn main() {
                                     cells
                                 },
                             };
+                        }
+
+                        // check wrap button clicks
+                        else if in_wrap(&canvas, &text_cache, x, y, is_wrap) {
+                            is_wrap = !is_wrap;
                         }
 
                         // check play button clicks

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,7 +94,7 @@ fn main() {
         if is_simulating {
             let curr_time = Instant::now();
             if curr_time.duration_since(last_updated) > interval {
-                cells = simulate(cells);
+                cells = simulate(cells, false);
                 last_updated = curr_time;
             }
         }


### PR DESCRIPTION
Currently, as described in #14 , the ability to have a grid where cells do not wrap around is important. As this is expected behavior for most patterns, we have implemented it. More specifically, this PR:

- implements a grid simulation where cells past the boundary simply disappear
- sets this as the default
- allows the user the switch between WRAP mode and VOID mode