### PR TITLE
Allow user to zoom in and out

### DIFF
--- a/src/life.rs
+++ b/src/life.rs
@@ -35,9 +35,25 @@ pub fn simulate(cells: Vec<Vec<bool>>, is_wrap: bool) -> Vec<Vec<bool>> {
 
     // iterate through cells and apply the rules
     for i in 0..rows {
+        // if the previous row, this row, and the next row are all false, can skip
+        if i > 0 && i < rows - 1 {
+            let mut all_false = true;
+            for row in i-1..=i+1 {
+                for j in 0..cols {
+                    if cells[row][j] {
+                        all_false = false;
+                        break;
+                    }
+                }
+                if !all_false { break; }
+            }
+            if all_false { continue; }
+        }
+        
         for j in 0..cols {
             // slice to pass in for rule application
             let mut slice: Vec<Vec<bool>> = vec![vec![false; 3]; 3];
+            let mut is_zero = true;
 
             if is_wrap {
                 // utilize wrap-around coordinates and fill the slice 
@@ -46,6 +62,7 @@ pub fn simulate(cells: Vec<Vec<bool>>, is_wrap: bool) -> Vec<Vec<bool>> {
                         let row = (i + rows - 1 + di) % rows;
                         let col = (j + cols - 1 + dj) % cols;
                         slice[di][dj] = cells[row][col];
+                        if cells[row][col] { is_zero = false; }
                     }
                 }
             } else {
@@ -56,10 +73,19 @@ pub fn simulate(cells: Vec<Vec<bool>>, is_wrap: bool) -> Vec<Vec<bool>> {
                 } else {
                     for di in 0..3 {
                         for dj in 0..3 {
-                            slice[di][dj] = cells[i + di - 1][j + dj - 1];
+                            let row = i + di - 1;
+                            let col = j + dj - 1;
+                            slice[di][dj] = cells[row][col];
+                            if cells[row][col] { is_zero = false; }
                         }
                     }
                 }
+            }
+
+            // if it is all zeroes, then no need to apply rules
+            if is_zero {
+                ret_cells[i][j] = false;
+                continue;
             }
 
             // apply the rules

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ pub mod life;
 pub mod text;
 pub mod ui;
 
+use std::cmp::max;
 use std::time::{Duration, Instant};
 
 use controls::{calc_slider, in_pause, in_play, in_slider, in_upload, in_wrap, render_pause, render_play, render_slider, render_upload, render_wrap};
@@ -37,6 +38,7 @@ const UPLOAD_BYTES: &[u8] = include_bytes!("../assets/icons/upload.png");
 // size of the simulation
 const SIMULATED_ROWS: usize = 60;
 const SIMULATED_COLS: usize = 60;
+const MIN_CELL_SIZE: i32 = 5;
 
 fn main() {
     // initialize SDL contexts and windows
@@ -72,6 +74,7 @@ fn main() {
     let mut is_slider_moving = false;
     let mut slider_length: f32 = 1.0;
     let mut is_wrap = false;
+    let mut cell_size = 30;
 
     // keep track of time between loops to update simulation
     let mut last_updated = Instant::now();
@@ -86,7 +89,10 @@ fn main() {
         canvas.set_draw_color(Color::WHITE);
         canvas.clear();
         let mut grid_dim: (i32, i32) = (0, 0);  // (rows, cols)
-        match render_grid(&mut canvas) {
+        match render_grid(&mut canvas,
+                          cell_size,
+                          SIMULATED_ROWS as i32 - 2,
+                          SIMULATED_COLS as i32 - 2) {
             Ok(res) => grid_dim = res,
             Err(_) => is_rendered = false,
         }
@@ -113,8 +119,8 @@ fn main() {
                 for j in 0..grid_dim.1 {
                     if cells[cells_start_y + i as usize][cells_start_x + j as usize] {
                         let grid_vec = Vector2::new(j, i);
-                        let new_cell = Cell::from_grid(grid_vec);
-                        render_cell(&mut canvas, new_cell);
+                        let new_cell = Cell::from_grid(grid_vec, cell_size);
+                        render_cell(&mut canvas, new_cell, cell_size);
                     }
                 }
             }
@@ -152,6 +158,9 @@ fn main() {
                 Event::Quit { .. } => {
                     break 'running
                 },
+                Event::MouseWheel { y, .. } => {
+                    cell_size = max(MIN_CELL_SIZE, cell_size + y);
+                },
                 Event::MouseButtonDown { x, y, .. } => {
                     // if initial click is in slider, set slider moving variable to true
                     if is_rendered && in_slider(&canvas, x, y) {
@@ -166,7 +175,7 @@ fn main() {
                     if is_rendered {
                         // get click and convert to grid coordinates
                         let click_vec = Vector2::new(x, y);
-                        let grid_vec = click_vec.to_grid(grid_dim.0, grid_dim.1);
+                        let grid_vec = click_vec.to_grid(grid_dim.0, grid_dim.1, cell_size);
 
                         // ensure click is within grid and update backend grid
                         if grid_vec.x >= 0 && grid_vec.y >= 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ use sdl2::video::Window;
 use sdl2::{EventPump, Sdl, VideoSubsystem};
 
 // speed for the simulation
-const MIN_SPEED: u64 = 500;
+const MIN_SPEED: u64 = 300;
 const MAX_SPEED: u64 = 1;
 const DEFAULT_SPEED: u64 = 1;
 
@@ -36,8 +36,8 @@ const FONT_BYTES: &[u8] = include_bytes!("../assets/fonts/FiraSans-Regular.ttf")
 const UPLOAD_BYTES: &[u8] = include_bytes!("../assets/icons/upload.png");
 
 // size of the simulation
-const SIMULATED_ROWS: usize = 60;
-const SIMULATED_COLS: usize = 60;
+const SIMULATED_ROWS: usize = 120;
+const SIMULATED_COLS: usize = 120;
 const MIN_CELL_SIZE: i32 = 5;
 
 fn main() {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -5,10 +5,8 @@ use sdl2::video::Window;
 
 use std::cmp::min;
 
-const CELL_SIZE: i32 = 30;
-const CELL_PADDING: i32 = 2;
+const CELL_PADDING: i32 = 1;
 pub const BUFFER_SIZE: i32 = 60;
-const MINIMAL_SCREEN_SIZE: u32 = 2 * BUFFER_SIZE as u32 + CELL_SIZE as u32;
 
 /// Struct to convert between grid coordinates and screen coordinates
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
@@ -23,28 +21,28 @@ impl Vector2 {
     }
     
     /// Convert provided grid coordinates to screen coordinates for the top left corner
-    pub fn to_screen(&self) -> Vector2 {
-        let x: i32 = BUFFER_SIZE + self.x * CELL_SIZE;
-        let y: i32 = BUFFER_SIZE + self.y * CELL_SIZE;
+    pub fn to_screen(&self, cell_size: i32) -> Vector2 {
+        let x: i32 = BUFFER_SIZE + self.x * cell_size;
+        let y: i32 = BUFFER_SIZE + self.y * cell_size;
         Vector2 { x, y }
     }
 
     /// Convert provided screen coordinates in Vector2 to grid coordinates
     /// Returns (-1, -1) if screen coordinates are outside of grid
-    pub fn to_grid(&self, cell_rows: i32, cell_cols: i32) -> Vector2 {
+    pub fn to_grid(&self, cell_rows: i32, cell_cols: i32, cell_size: i32) -> Vector2 {
         // check if self.x is outside of grid
-        if self.x <= BUFFER_SIZE || self.x >= cell_cols * CELL_SIZE + BUFFER_SIZE {
+        if self.x <= BUFFER_SIZE || self.x >= cell_cols * cell_size + BUFFER_SIZE {
             return Vector2 { x: -1, y: -1 };
         }
         
         // check if self.y is outside of grid
-        if self.y <= BUFFER_SIZE || self.y >= cell_rows * CELL_SIZE + BUFFER_SIZE {
+        if self.y <= BUFFER_SIZE || self.y >= cell_rows * cell_size + BUFFER_SIZE {
             return Vector2 { x: -1, y: -1 };
         }
 
         // otherwise, calculate grid coordinates
-        let x: i32 = (self.x - BUFFER_SIZE) / CELL_SIZE;
-        let y: i32 = (self.y - BUFFER_SIZE) / CELL_SIZE;
+        let x: i32 = (self.x - BUFFER_SIZE) / cell_size;
+        let y: i32 = (self.y - BUFFER_SIZE) / cell_size;
         Vector2 { x, y }
     }
 }
@@ -64,62 +62,68 @@ pub struct Cell {
 }
 
 impl Cell {
-    pub fn from_top_left(location: Vector2) -> Self {
+    pub fn from_top_left(location: Vector2, cell_size: i32) -> Self {
         Cell {
             top_left: Vector2::new(location.x, location.y),
-            top_right: Vector2::new(location.x + CELL_SIZE, location.y),
-            bottom_left: Vector2::new(location.x, location.y + CELL_SIZE),
-            bottom_right: Vector2::new(location.x + CELL_SIZE, location.y + CELL_SIZE),
+            top_right: Vector2::new(location.x + cell_size, location.y),
+            bottom_left: Vector2::new(location.x, location.y + cell_size),
+            bottom_right: Vector2::new(location.x + cell_size, location.y + cell_size),
         }
     }
 
-    pub fn from_grid(location: Vector2) -> Self {
-        let screen_loc: Vector2 = location.to_screen();
+    pub fn from_grid(location: Vector2, cell_size: i32) -> Self {
+        let screen_loc: Vector2 = location.to_screen(cell_size);
         Cell {
             top_left : Vector2::new(screen_loc.x, screen_loc.y),
-            top_right: Vector2::new(screen_loc.x + CELL_SIZE, screen_loc.y),
-            bottom_left: Vector2::new(screen_loc.x, screen_loc.y + CELL_SIZE),
-            bottom_right: Vector2::new(screen_loc.x + CELL_SIZE, screen_loc.y + CELL_SIZE),
+            top_right: Vector2::new(screen_loc.x + cell_size, screen_loc.y),
+            bottom_left: Vector2::new(screen_loc.x, screen_loc.y + cell_size),
+            bottom_right: Vector2::new(screen_loc.x + cell_size, screen_loc.y + cell_size),
         }
     }
 }
 
 /// Given the canvas context and a Cell, render a cell within the grid
-pub fn render_cell(canvas: &mut Canvas<Window>, cell: Cell) {
+pub fn render_cell(canvas: &mut Canvas<Window>, cell: Cell, cell_size: i32) {
     canvas.set_draw_color(Color::GRAY);
     let cell_start_x: i32 = cell.top_left.x + CELL_PADDING;
     let cell_start_y: i32 = cell.top_left.y + CELL_PADDING;
-    let cell_dim: u32 = (CELL_SIZE - 2 * CELL_PADDING + 1) as u32;
+    let cell_dim: u32 = (cell_size - 2 * CELL_PADDING + 1) as u32;
     let cell_rect = Rect::new(cell_start_x, cell_start_y, cell_dim, cell_dim);
     canvas.fill_rect(cell_rect).unwrap();
 }
 
 /// Given the canvas context, render the grid
 /// Returns a Result containing (rows, cols)
-pub fn render_grid(canvas: &mut Canvas<Window>) -> Result<(i32, i32), String> {
+pub fn render_grid(
+    canvas: &mut Canvas<Window>, 
+    cell_size: i32,
+    max_rows: i32,
+    max_cols: i32,
+) -> Result<(i32, i32), String> {
     // get screen size and set draw color
     let screen_size: (u32, u32) = canvas.output_size().unwrap();
     canvas.set_draw_color(Color::BLACK);
     
     // calculate number of cells from cell size and available screen size
     // first, ensure screen size is large enough
-    if screen_size.0 < MINIMAL_SCREEN_SIZE || screen_size.1 < MINIMAL_SCREEN_SIZE {
+    let minimal_screen_size: u32 = 2 * BUFFER_SIZE as u32 + cell_size as u32;
+    if screen_size.0 < minimal_screen_size || screen_size.1 < minimal_screen_size {
         eprintln!("WARNING: Screen not large enough to render grid");
         return Err("Screen not large enough to render grid".to_string());
     }
     // then, calculate available space for cells
     let available_width: i32 = screen_size.0 as i32 - 2 * BUFFER_SIZE;
     let available_height: i32 = screen_size.1 as i32 - 2 * BUFFER_SIZE;
-    let rows: i32 = min(60, available_height / CELL_SIZE);
-    let cols: i32 = min(60, available_width / CELL_SIZE);
+    let rows: i32 = min(max_rows, available_height / cell_size);
+    let cols: i32 = min(max_cols, available_width / cell_size);
 
     // draw the lines for the rows
     for i in 0..=rows {
         let start_point: Vector2 = Cell::from_top_left(Vector2::new(0, i as i32)
-            .to_screen())
+            .to_screen(cell_size), cell_size)
             .top_left;
         let end_point: Vector2 = Cell::from_top_left(Vector2::new(cols - 1, i as i32)
-            .to_screen())
+            .to_screen(cell_size), cell_size)
             .top_right;
         canvas.draw_line(start_point, end_point).unwrap();
     }
@@ -127,10 +131,10 @@ pub fn render_grid(canvas: &mut Canvas<Window>) -> Result<(i32, i32), String> {
     // draw the lines for the columns
     for i in 0..=cols {
         let start_point: Vector2 = Cell::from_top_left(Vector2::new(i as i32, 0)
-            .to_screen())
+            .to_screen(cell_size), cell_size)
             .top_left;
         let end_point: Vector2 = Cell::from_top_left(Vector2::new(i as i32, rows - 1)
-            .to_screen())
+            .to_screen(cell_size), cell_size)
             .bottom_left;
         canvas.draw_line(start_point, end_point).unwrap();
     }


### PR DESCRIPTION
This PR implements zooming in and out of the grid. More specifically:

- the user can use the mouse wheel or trackpad to zoom
- the cell size dynamically change, revealing more of the grid
- grid simulation has been doubled to 120x120, taking advantage of the more space
- likewise, optimizations have been implemented to offset the computation cost of this larger simulation